### PR TITLE
Fix/poll retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- New configuration property "data-poll_retry" to set how many poll retry attempts to perform before exiting with error code, by default 10 retries.
+
 ## [1.0.1]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@
 - [License](#license)
 - [Acknowledgments](#acknowledgments)
 
-
 ## Introduction
 
 The purpose of this module is to enable third-party services to easily integrate with Arbetsförmedlingen's AF-Connect infrastructure in order to obtain data/documents/certificates related to registered jobseekers and/or employers with their explicit consent.
@@ -165,6 +164,7 @@ The table below shows all available configuration properties, default values and
 | --------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------ |
 | data-label                  | AF Connect                                         | Label displayed on the AF Connect Module interactive button.                         |
 | data-poll_rate              | 1000                                               | Data polling frequency, described in milliseconds.                                   |
+| data-poll_retry             | 10                                                 | Data polling retry maximum count, e.g. if network connectivity has been lost.        |
 | data-poll_timeout           | 300000                                             | Data polling timeout, described in milliseconds.                                     |
 | data-af_connect_url         | https://af-connect.local                           | URL to AF-Connect service to open in new tab/window when the user clicks the button. |
 | data-af_portability_url     | http://af-connect.local:8080                       | URL to service where session token and user data can be obtained.                    |

--- a/dist/af-connect-module.bundle.js
+++ b/dist/af-connect-module.bundle.js
@@ -10,6 +10,7 @@ Array.prototype.forEach.call(containers, container => {
   let config = {
     label: container.getAttribute("data-label") || "AF Connect",
     pollRate: container.getAttribute("data-poll_rate") || "1000", // 1 second
+    pollRetry: container.getAttribute("data-poll_retry") || "10",
     timeout: container.getAttribute("data-poll_timeout") || "300000", // 5 minutes
     afConnectUrl:
       container.getAttribute("data-af_connect_url") ||
@@ -96,10 +97,23 @@ const fetchSequence = config => {
           .open(config.afConnectUrl + "?sessionToken=" + sessionToken, "_blank")
           .focus();
 
+        let retry = 0;
+        let retryMax = config.pollRetry;
+
         let timeoutId;
+        let awaitingResponse = false;
         const timerId = setInterval(() => {
+          // Only poll for envelope if there are no ongoing request.
+          if (awaitingResponse) {
+            return;
+          }
+
+          awaitingResponse = true;
           return getEnvelope(config, sessionToken)
             .then(cv => {
+              awaitingResponse = false;
+              retry = 0;
+
               if (cv !== undefined) {
                 clearInterval(timerId);
                 clearTimeout(timeoutId);
@@ -110,8 +124,15 @@ const fetchSequence = config => {
               }
             })
             .catch(err => {
-              clearInterval(timerId);
-              reject(err);
+              awaitingResponse = false;
+              if (retry < retryMax) {
+                // Error occurred upon polling for envelope, retrying.
+                retry++;
+              } else {
+                // Too many errors occurred upon polling for envelope, stop polling with error code.
+                clearInterval(timerId);
+                reject(err);
+              }
             });
         }, config.pollRate);
 

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ Array.prototype.forEach.call(containers, container => {
   let config = {
     label: container.getAttribute("data-label") || "AF Connect",
     pollRate: container.getAttribute("data-poll_rate") || "1000", // 1 second
+    pollRetry: container.getAttribute("data-poll_retry") || "10",
     timeout: container.getAttribute("data-poll_timeout") || "300000", // 5 minutes
     afConnectUrl:
       container.getAttribute("data-af_connect_url") ||

--- a/lib/connect-module.js
+++ b/lib/connect-module.js
@@ -56,10 +56,23 @@ const fetchSequence = config => {
           .open(config.afConnectUrl + "?sessionToken=" + sessionToken, "_blank")
           .focus();
 
+        let retry = 0;
+        let retryMax = config.pollRetry;
+
         let timeoutId;
+        let awaitingResponse = false;
         const timerId = setInterval(() => {
+          // Only poll for envelope if there are no ongoing request.
+          if (awaitingResponse) {
+            return;
+          }
+
+          awaitingResponse = true;
           return getEnvelope(config, sessionToken)
             .then(cv => {
+              awaitingResponse = false;
+              retry = 0;
+
               if (cv !== undefined) {
                 clearInterval(timerId);
                 clearTimeout(timeoutId);
@@ -70,8 +83,15 @@ const fetchSequence = config => {
               }
             })
             .catch(err => {
-              clearInterval(timerId);
-              reject(err);
+              awaitingResponse = false;
+              if (retry < retryMax) {
+                // Error occurred upon polling for envelope, retrying.
+                retry++;
+              } else {
+                // Too many errors occurred upon polling for envelope, stop polling with error code.
+                clearInterval(timerId);
+                reject(err);
+              }
             });
         }, config.pollRate);
 


### PR DESCRIPTION
Fixes the issue where the AF-Connect-Module abruptly stops polling(before timeout) upon network connectivity problem.

This PR enables the AF-Connect-Module to perform a set amount of retries before exiting the polling sequence.

- The maximum of retries is configured with property "data-poll_retry".
- The retry counter will reset upon regaining connectivity regardless if the envelope was received.

**This is not a breaking change**