### PR TITLE
Changed the default api-key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New configuration property "data-poll_retry" to set how many poll retry attempts to perform before exiting with error code, by default 10 retries.
 
+### Changed
+
+- Changed the default api-key to be "dummykey".
+
 ## [1.0.1]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -136,11 +136,11 @@ Open up the browser developer tools console and you will see that the `onRespons
 
 In order to integrate your own website with AF-Connect integration environment you must apply/adjust the configuration properties as listed below.
 
-| Configuration property      | Af-connect integration env.                        | Description                        |
-| --------------------------- | -------------------------------------------------- | ---------------------------------- |
-| data-af_connect_url         | https://af-connect-int.jobtechdev.se               | se [Configuration](#configuration) |
-| data-af_portability_url     | https://af-portability-int.jobtechdev.se           | se [Configuration](#configuration) |
-| data-af_portability_api_key | dummydummydummydummydummydummydummydummydummydummy | se [Configuration](#configuration) |
+| Configuration property      | Af-connect integration env.              | Description                        |
+| --------------------------- | ---------------------------------------- | ---------------------------------- |
+| data-af_connect_url         | https://af-connect-int.jobtechdev.se     | se [Configuration](#configuration) |
+| data-af_portability_url     | https://af-portability-int.jobtechdev.se | se [Configuration](#configuration) |
+| data-af_portability_api_key | dummykey                                 | se [Configuration](#configuration) |
 
 Find all available configuration properties in section: [Configuration](#configuration)
 
@@ -160,16 +160,16 @@ Here's an example for how you can reduce the data polling rate to just once per 
 
 The table below shows all available configuration properties, default values and usage description.
 
-| Configuration property      | Default value                                      | Description                                                                          |
-| --------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| data-label                  | AF Connect                                         | Label displayed on the AF Connect Module interactive button.                         |
-| data-poll_rate              | 1000                                               | Data polling frequency, described in milliseconds.                                   |
-| data-poll_retry             | 10                                                 | Data polling retry maximum count, e.g. if network connectivity has been lost.        |
-| data-poll_timeout           | 300000                                             | Data polling timeout, described in milliseconds.                                     |
-| data-af_connect_url         | https://af-connect.local                           | URL to AF-Connect service to open in new tab/window when the user clicks the button. |
-| data-af_portability_url     | http://af-connect.local:8080                       | URL to service where session token and user data can be obtained.                    |
-| data-af_portability_api_key | dummydummydummydummydummydummydummydummydummydummy | The API key used when querying for session token and polling for data.               |
-| data-on_response            | undefined                                          | Name of global callback function to call upon polling success/failure.               |
+| Configuration property      | Default value                | Description                                                                          |
+| --------------------------- | ---------------------------- | ------------------------------------------------------------------------------------ |
+| data-label                  | AF Connect                   | Label displayed on the AF Connect Module interactive button.                         |
+| data-poll_rate              | 1000                         | Data polling frequency, described in milliseconds.                                   |
+| data-poll_retry             | 10                           | Data polling retry maximum count, e.g. if network connectivity has been lost.        |
+| data-poll_timeout           | 300000                       | Data polling timeout, described in milliseconds.                                     |
+| data-af_connect_url         | https://af-connect.local     | URL to AF-Connect service to open in new tab/window when the user clicks the button. |
+| data-af_portability_url     | http://af-connect.local:8080 | URL to service where session token and user data can be obtained.                    |
+| data-af_portability_api_key | dummykey                     | The API key used when querying for session token and polling for data.               |
+| data-on_response            | undefined                    | Name of global callback function to call upon polling success/failure.               |
 
 ## Build from source
 

--- a/dist/af-connect-module.bundle.js
+++ b/dist/af-connect-module.bundle.js
@@ -19,8 +19,7 @@ Array.prototype.forEach.call(containers, container => {
       container.getAttribute("data-af_portability_url") ||
       "http://af-connect.local:8080",
     afPortabilityApiKey:
-      container.getAttribute("data-af_portability_api_key") ||
-      "dummydummydummydummydummydummydummydummydummydummy",
+      container.getAttribute("data-af_portability_api_key") || "dummykey",
     onResponse: container.getAttribute("data-on_response") || undefined
   };
 

--- a/index.js
+++ b/index.js
@@ -18,8 +18,7 @@ Array.prototype.forEach.call(containers, container => {
       container.getAttribute("data-af_portability_url") ||
       "http://af-connect.local:8080",
     afPortabilityApiKey:
-      container.getAttribute("data-af_portability_api_key") ||
-      "dummydummydummydummydummydummydummydummydummydummy",
+      container.getAttribute("data-af_portability_api_key") || "dummykey",
     onResponse: container.getAttribute("data-on_response") || undefined
   };
 


### PR DESCRIPTION
The following PR (https://github.com/MagnumOpuses/af-connect-mock/pull/7) allows us to use a shorter api-key "dummykey". It looks nicer in the documentation