### PR TITLE
Release preparation 1.0.2-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.2-beta]
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ npm run test
 
 ## Versions, current dev state and future
 
-v1.0.1
+1.0.2-beta
 
 ## Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "af-connect-module",
-  "version": "0.1.0",
+  "version": "1.0.2-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "af-connect-module",
-  "version": "1.0.1",
+  "version": "1.0.2-beta",
   "description": "![alt text][logo]",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## [1.0.2-beta]

### Fixed

- AF-Connect button now disabled while fetching session and polling for envelope. Button is re-activated upon successful envelope response, received error code or timeout.

### Added

- New configuration property "data-poll_retry" to set how many poll retry attempts to perform before exiting with error code, by default 10 retries.

### Changed

- Changed the default api-key to be "dummykey".