### PR TITLE
Forrr popup window

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ npm run test
 
 ## Built with
 
-- NPM v6.4.1 (Node package manager)
+- NPM v6.14.12 (Node package manager)
 - Browserify v16.5.0 (Javascript bundler for browser)
 
 ## Versions, current dev state and future

--- a/dist/af-connect-module.bundle.js
+++ b/dist/af-connect-module.bundle.js
@@ -153,12 +153,13 @@ const getEnvelope = (config, session) => {
 const fetchSequence = (config, button) => {
   button.style["background-color"] = "#AAAAAA";
   button.setAttribute("disabled", "");
+
   return getSession(config)
     .then(sessionToken => {
       return new Promise((resolve, reject) => {
         window
-          .open(config.afConnectUrl + "?sessionToken=" + sessionToken, "_blank")
-          .focus();
+            .open(config.afConnectUrl + "?sessionToken=" + sessionToken, "Arbetsförmedlingen Connect Once", "location=yes,resizable=no,scrollbars=no,screenX=10,screenY=10,innerWidth=800,innerHeight=800,status=off,toolbar=off,location=off" )
+            .focus();
 
         let retry = 0;
         let retryMax = config.pollRetry;

--- a/lib/connect-module.js
+++ b/lib/connect-module.js
@@ -77,12 +77,13 @@ const getEnvelope = (config, session) => {
 const fetchSequence = (config, button) => {
   button.style["background-color"] = "#AAAAAA";
   button.setAttribute("disabled", "");
+
   return getSession(config)
     .then(sessionToken => {
       return new Promise((resolve, reject) => {
         window
-          .open(config.afConnectUrl + "?sessionToken=" + sessionToken, "_blank")
-          .focus();
+            .open(config.afConnectUrl + "?sessionToken=" + sessionToken, "Arbetsförmedlingen Connect Once", "location=yes,resizable=no,scrollbars=no,screenX=10,screenY=10,innerWidth=800,innerHeight=800,status=off,toolbar=off,location=off" )
+            .focus();
 
         let retry = 0;
         let retryMax = config.pollRetry;


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the [contribution guidelines](CONTRIBUTING.md), then fill out the blanks below.)

---

This opens the AF Connect related content in a popup window, intended to contain the navigation steps
for carrying out transfer of the shared profile. (Login, Select Profile, Preview, Consent)
...


This intends to close Jira  ONCE-55 "Open Consent page in small window".
...

**Where has this been tested?**
 - Macbook Pro 15 (2017)
-  MacOS Catalina 10.15.7
 - Google Chrome 90.0.4430.93 (Official Build) (x86_64)
 